### PR TITLE
Disable pod security policy on debug

### DIFF
--- a/charts/fleet-agent/templates/deployment.yaml
+++ b/charts/fleet-agent/templates/deployment.yaml
@@ -25,10 +25,11 @@ spec:
         - --debug
         - --debug-level
         - {{ quote .Values.debugLevel }}
-        {{- end }}
+        {{- else }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        {{- end }}
       serviceAccountName: fleet-agent
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
 {{- if .Values.fleetAgent.nodeSelector }}
@@ -38,7 +39,9 @@ spec:
 {{- if .Values.fleetAgent.tolerations }}
 {{ toYaml .Values.fleetAgent.tolerations | indent 8 }}
 {{- end }}
+{{- if not .Values.debug }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+{{- end }}

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -34,13 +34,14 @@ spec:
         - --debug
         - --debug-level
         - {{ quote .Values.debugLevel }}
+        {{- else }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         {{- end }}
         {{- if not .Values.gitops.enabled }}
         - --disable-gitops
         {{- end }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
       serviceAccountName: fleet-controller
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
 {{- if .Values.nodeSelector }}
@@ -50,7 +51,9 @@ spec:
 {{- if .Values.tolerations }}
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
+{{- if not .Values.debug }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+{{- end }}


### PR DESCRIPTION
This is necessary until KEP-1441 is implemented, see:

https://github.com/kubernetes/enhancements/blob/cfbe9a3471db50ae4c6ec89a9ddfc8801cc6976d/keps/sig-cli/1441-kubectl-debug/README.md#debugging-profiles

Signed-off-by: Silvio Moioli <silvio@moioli.net>